### PR TITLE
Fix codegen struct hierarchy order bug

### DIFF
--- a/codegen/valaccodestructmodule.vala
+++ b/codegen/valaccodestructmodule.vala
@@ -52,6 +52,10 @@ public abstract class Vala.CCodeStructModule : CCodeBaseModule {
 			}
 			return;
 		}
+		
+		if (st.base_struct != null) {
+			generate_struct_declaration (st.base_struct, decl_space);
+		}
 
 		if (get_ccode_has_type_id (st)) {
 			decl_space.add_type_declaration (new CCodeNewline ());


### PR DESCRIPTION
I found a bug when using struct inheritance. When struct B inherits from a non-simple struct A and I want to use struct B in a separate file (and struct A is not referenced in the file), then the C code generation will put the definition of struct B before the definition of struct A. This results in a C compilation error. A simple fix is to check if the non-simple struct has a base struct, and if so, explicitly call for the base struct's declaration.

Following is a minimal showcase for this bug:
#### main.vala

`void main() { Size2 s = Size2(); }`
#### struct.vala

`struct Vec2 { float x; float y; } struct Size2 : Vec2 { }`
#### Compilation

Compile with `valac main.vala struct.vala`
#### Result

`error: syntax error before "Size2"` etc.
