### PR TITLE
g_socket_create_source return Source but the callback is GSocketSourceFunc

### DIFF
--- a/vapi/gio-2.0.vapi
+++ b/vapi/gio-2.0.vapi
@@ -3194,7 +3194,7 @@ namespace GLib {
 	public interface DatagramBased : GLib.Object {
 		public abstract GLib.IOCondition condition_check (GLib.IOCondition condition);
 		public abstract bool condition_wait (GLib.IOCondition condition, int64 timeout, GLib.Cancellable? cancellable = null) throws GLib.Error;
-		public abstract GLib.Source create_source (GLib.IOCondition condition, GLib.Cancellable? cancellable = null);
+		public abstract GLib.SocketSource create_source (GLib.IOCondition condition, GLib.Cancellable? cancellable = null);
 		public abstract int receive_messages ([CCode (array_length_cname = "num_messages", array_length_pos = 1.5, array_length_type = "guint")] GLib.InputMessage[] messages, int flags, int64 timeout, GLib.Cancellable? cancellable = null) throws GLib.Error;
 		public abstract int send_messages ([CCode (array_length_cname = "num_messages", array_length_pos = 1.5, array_length_type = "guint")] GLib.OutputMessage[] messages, int flags, int64 timeout, GLib.Cancellable? cancellable = null) throws GLib.Error;
 	}


### PR DESCRIPTION
so in vala binding create_source for socket has to return GLib.SocketSource

this is a regression introduced in cbd7b680395abcc5a2bea3d3f51455f247cd97c1

without this patch, the example "UDP Server example" in https://wiki.gnome.org/Projects/Vala/GIONetworkingSample

does not build and the line:
`var source = socket.create_source (IOCondition.IN);`
has to be changed in
`var source = (SocketSource) socket.create_source (IOCondition.IN);`
